### PR TITLE
recognize Response.direct_passthrough

### DIFF
--- a/flask_gzip.py
+++ b/flask_gzip.py
@@ -15,6 +15,7 @@ class Gzip(object):
 
         if response.status_code < 200 or \
            response.status_code >= 300 or \
+           response.direct_passthrough or \
            len(response.data) < self.minimum_size or \
            'gzip' not in accept_encoding.lower() or \
            'Content-Encoding' in response.headers:


### PR DESCRIPTION
If `Response.direct_passthrough == True` you may not read or write `Response.data`.  Otherwise you get 

    RuntimeError: Attempted implicit sequence conversion but the response object is in direct passthrough mode.